### PR TITLE
Support for new bracket colorization in 1.60

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -20,6 +20,9 @@
         ["“", "”"],
         ["’", "‘"]
     ],
+    "colorizedBracketPairs": [
+        ["(", ")"]
+    ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
         ["[", "]"],


### PR DESCRIPTION
VSCode v1.60.0 has brought native support for bracket colorization.
When enabled nested bracket pairs will be highlighted differently.
[Per this comment](https://github.com/microsoft/vscode/issues/132336#issuecomment-913204643) it has to be set up as language rule.

In this PR I've only enabled to highlight round brackets, because they are the only type of brackets, that are nested and could need a highlight.

Please note: This changes nothing as long the user hat not enabled the `editor.bracketPairColorization.enabled` setting. But if the user has enabled it, they will enjoy the correct setting.
(Brackets _not_ highlighted: `<>,[],{}`. Otherwise they would be, too. That is irritating.)